### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dollar [![Build Status](https://travis-ci.org/ankurp/Dollar.svg?branch=master)](
 
 Dollar is a Swift library that provides useful functional programming helper methods without extending any built in objects. It is similar to [Lo-Dash](https://lodash.com) or [Underscore.js](http://underscorejs.org) in Javascript.
 
-[Cent](https://github.com/ankurp/Cent) is a library that extends certain Swift object types using the extension feature and gives its two cents to Swift language. It is now moved into a seperate repo to support `carthage` and upcoming `Swift Package Manager`
+[Cent](https://github.com/ankurp/Cent) is a library that extends certain Swift object types using the extension feature and gives its two cents to Swift language. It is now moved into a separate repo to support `carthage` and upcoming `Swift Package Manager`
 
 ## Contents ##
 


### PR DESCRIPTION
Typo 'Seperate' -> 'Separate' ;)
